### PR TITLE
fix for the horizontal scroll for the hero component

### DIFF
--- a/starter/src/app/_components/universal/hero.tsx
+++ b/starter/src/app/_components/universal/hero.tsx
@@ -8,7 +8,7 @@ interface HeroProps {
 export const Hero = ({ title, children }: HeroProps) => {
   return (
     <div
-      className="flex min-h-96 w-screen flex-col justify-center bg-cover bg-center bg-no-repeat py-20"
+      className="flex min-h-96 flex-col justify-center bg-cover bg-center bg-no-repeat py-20"
       style={{ backgroundImage: "url('/hero.jpg')" }}>
       <div className="container mt-16 flex flex-col items-center justify-center gap-12 px-4 py-6">
         <h1 className="font-display text-5xl font-extrabold tracking-tight text-white">


### PR DESCRIPTION
before
<img width="1498" alt="image" src="https://github.com/calcom/examples/assets/3423341/0e3f6fb0-8c10-4392-8438-27542258ea1e">

after
<img width="1501" alt="image" src="https://github.com/calcom/examples/assets/3423341/f89af9a1-9aca-4d7e-b726-79879b6dd09b">

we don't need full width here since the div is a block component and fill the entire width by default