### PR TITLE
fix: signing up

### DIFF
--- a/src/cal/auth.ts
+++ b/src/cal/auth.ts
@@ -31,7 +31,14 @@ export async function signUp({ email, name, user }: CreateManagedUserInput & { u
       connectOrCreate: {
         where: { id: userCreation.data.user.id },
         create: {
-          ...userCreation.data.user,
+          id: userCreation.data.user.id,
+          email: userCreation.data.user.email,
+          username: userCreation.data.user.username,
+          timeZone: userCreation.data.user.timeZone,
+          weekStart: userCreation.data.user.weekStart,
+          createdDate: userCreation.data.user.createdDate,
+          timeFormat: userCreation.data.user.timeFormat,
+          defaultScheduleId: userCreation.data.user.defaultScheduleId,
         },
       },
     },


### PR DESCRIPTION
## Problem

When signing up it says `Invalid credentials` and database update fails because of `locale` field not existing
<img width="1114" alt="Screenshot 2024-07-30 at 10 14 05" src="https://github.com/user-attachments/assets/5d84a66f-570f-44a2-b656-aafc94496a76">

<img width="1429" alt="Screenshot 2024-07-30 at 10 14 20" src="https://github.com/user-attachments/assets/9746dc1c-9091-432c-b250-f305ca7d86a9">

It was possible to then repeatedly click the sign up button and somehow get signed in, but then visiting the dashboard would crash and it was not possible to connect google calendar.

## Why
On line 8 is invoked creation of managed user, and in PR https://github.com/calcom/cal.com/pull/15794 `locale` was added to managed user output, which then is spread on line 34 but `locale` does not exist in starter kit schema:
<img width="1213" alt="Screenshot 2024-07-30 at 10 15 47" src="https://github.com/user-attachments/assets/567bb713-2ae3-4166-8cc6-22833b765f8c">

## Solution
Stop spreading managed user response and only pick specific keys. We could add new properties to database schema and continue spreading, but downstream v2 API changes could potentially make starter kit again, so instead pick only what we need and add more properties only when needed not based on v2 API response.

<img width="1699" alt="Screenshot 2024-07-30 at 10 18 28" src="https://github.com/user-attachments/assets/b84352c5-49c9-4a23-83a1-85cb551558e9">
